### PR TITLE
fix(mail): migrate mail persistence in filesystem

### DIFF
--- a/.agent/rules/context.md
+++ b/.agent/rules/context.md
@@ -50,6 +50,17 @@
     - **Realism**: Global mute (`Howler.mute(true)`) silences the system without stopping background processes (e.g., music keep "playing" silently).
     - **Binary Metadata**: Custom ID3 parser (`src/utils/id3Parser.ts`) extracts professional tags (TIT2, TPE1, TALB) from MP3 files.
     - **Asset Fetching**: Metadata resolution for local assets uses `fetch` with `Range: bytes=0-512KB` to efficiently read headers without full downloads.
+
+7.  **System Initialization**:
+    - **Timestamp**: `STORAGE_KEYS.INSTALL_DATE` is set upon Onboarding completion to mark the exact "System Install Time".
+    - **Usage**: Used by Calendar for historical accuracy of the "Loop Started" event.
+    </architecture_mechanics>
+
+8.  **Simulated Cloud Services**:
+    -   **Pattern**: Services (e.g., `MailService`) act as "Cloud" backends, separate from the local VFS.
+    -   **Persistence**: They independently use `localStorage` (e.g., `trustmail-db`) to persist state across sessions/reloads.
+    -   **Interface**: Apps interact with them via static Service classes. Apps then "cache" this data locally (e.g., in `mail.json`) to simulate local state syncing.
+    -   **Gameplay**: This separation exists to support gameplay mechanics like "Offline Mode" or "Hacking", where the local file (`mail.json`) might be out of sync or contain vulnerable plain-text secrets like `recoverySecret`.
     </architecture_mechanics>
 
 <critical_rules>

--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ Or use the [GitHub Pages](https://mental-os.github.io/Aurora-OS.js) (LIVE DEMO)
 
 - **Photos App**: Full-featured gallery with albums, favorites, lightbox, and background library scanning.
 - **Mock Content**: Initial set of high-quality mock images seeded to `~/Pictures`.
+- **Simulated Cloud Services**: Added initial support for simulated cloud services (e.g., TrustMail accounts DB).
+- **TrustMail**: Added Account Recovery system with secret key generation and storage.
+
+### Removed
+
+- **TrustMail and Mail**: Dependency on local inbox and outbox.
+- **TrustMail**: Removed single-account limitation (multi-account support).
 
 ### Improved
 
@@ -132,6 +139,7 @@ Or use the [GitHub Pages](https://mental-os.github.io/Aurora-OS.js) (LIVE DEMO)
 - **Calendar first event**: aka. "Loop Started" event is now set to follow the onboarding complition time.
 - **Time source**: now influence Calendar app (local time vs. server time).
 - **Modals**: such as "Open File" or "Create/Edit Event" blurs the background.
+- **Main Services & Mail**: Trash functionality and permanent deletion.
 
 ### Fixed
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -56,6 +56,13 @@
     - **Usage**: Used by Calendar for historical accuracy of the "Loop Started" event.
     </architecture_mechanics>
 
+8.  **Simulated Cloud Services**:
+    -   **Pattern**: Services (e.g., `MailService`) act as "Cloud" backends, separate from the local VFS.
+    -   **Persistence**: They independently use `localStorage` (e.g., `trustmail-db`) to persist state across sessions/reloads.
+    -   **Interface**: Apps interact with them via static Service classes. Apps then "cache" this data locally (e.g., in `mail.json`) to simulate local state syncing.
+    -   **Gameplay**: This separation exists to support gameplay mechanics like "Offline Mode" or "Hacking", where the local file (`mail.json`) might be out of sync or contain vulnerable plain-text secrets like `recoverySecret`.
+    </architecture_mechanics>
+
 <critical_rules>
 
 - **FS Integrity**: ALWAYS use `createFile`, `writeFile`, `deleteNode` from `useFileSystem`.

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -664,6 +664,8 @@ export const de: TranslationDict = {
       archive: 'Archivieren',
       unarchive: 'Dearchivieren',
       delete: 'Löschen',
+      restore: 'Wiederherstellen',
+      deleteForever: 'Endgültig löschen',
     },
     time: {
       minutesAgo: 'vor {{minutes}}m',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -674,6 +674,8 @@ export const en: TranslationDict = {
       archive: 'Archive',
       unarchive: 'Unarchive',
       delete: 'Delete',
+      restore: 'Restore',
+      deleteForever: 'Delete permanently',
     },
     time: {
       minutesAgo: '{{minutes}}m ago',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -729,6 +729,8 @@ export const es: TranslationDict = {
       archive: 'Archivar',
       unarchive: 'Desarchivar',
       delete: 'Eliminar',
+      restore: 'Restaurar',
+      deleteForever: 'Eliminar definitivamente',
     },
     time: {
       minutesAgo: 'hace {{minutes}} min',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -731,6 +731,8 @@ export const fr: TranslationDict = {
       archive: 'Archiver',
       unarchive: 'Désarchiver',
       delete: 'Supprimer',
+      restore: 'Restaurer',
+      deleteForever: 'Supprimer définitivement',
     },
     time: {
       minutesAgo: 'il y a {{minutes}} min',

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -670,6 +670,8 @@ export const pt: TranslationDict = {
       archive: 'Arquivar',
       unarchive: 'Desarquivar',
       delete: 'Excluir',
+      restore: 'Restaurar',
+      deleteForever: 'Excluir permanentemente',
     },
     time: {
       minutesAgo: 'há {{minutes}}m',

--- a/src/i18n/locales/ro.ts
+++ b/src/i18n/locales/ro.ts
@@ -728,6 +728,8 @@ export const ro: TranslationDict = {
             archive: 'Arhivează',
             unarchive: 'Dezarhivează',
             delete: 'Șterge',
+            restore: 'Restaurează',
+            deleteForever: 'Șterge Definitiv',
         },
         time: {
             minutesAgo: 'acum {{minutes}}m',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -671,6 +671,8 @@ export const zh: TranslationDict = {
 			archive: '归档',
 			unarchive: '取消归档',
 			delete: '删除',
+			restore: '恢复',
+			deleteForever: '永久删除',
 		},
 		time: {
 			minutesAgo: '{{minutes}} 分钟前',

--- a/src/services/MailService.ts
+++ b/src/services/MailService.ts
@@ -1,0 +1,143 @@
+import { Email } from "@/components/apps/Mail";
+import { encodePassword, decodePassword } from "@/utils/authUtils";
+import { STORAGE_KEYS } from "@/utils/memory";
+
+const DB_KEY = STORAGE_KEYS.MAIL_SERVER_DB;
+
+export interface MailAccount {
+  email: string;
+  passwordHash: string; // Encrypted password
+  name: string;
+  createdAt: string;
+  recoverySecret: string; // Plain text secret for recovery
+  emails: Email[];
+}
+
+export interface MailDatabase {
+  accounts: Record<string, MailAccount>; // email -> account
+}
+
+class MailServiceImpl {
+  private getDB(): MailDatabase {
+    if (typeof window === "undefined") return { accounts: {} };
+
+    const stored = localStorage.getItem(DB_KEY);
+    if (!stored) {
+      return { accounts: {} };
+    }
+
+    try {
+      return JSON.parse(stored);
+    } catch (e) {
+      console.error("MailService: Failed to parse DB", e);
+      return { accounts: {} };
+    }
+  }
+
+  private saveDB(db: MailDatabase) {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(DB_KEY, JSON.stringify(db));
+  }
+
+  // Generate a random recovery secret (simulated 4-word phrase or code)
+  private generateSecret(): string {
+    return Array.from({ length: 4 }, () => Math.random().toString(36).substring(2, 7)).join('-');
+  }
+
+  createAccount(
+    email: string,
+    password: string,
+    name: string = "User"
+  ): { success: boolean; secret?: string } {
+    const db = this.getDB();
+
+    if (db.accounts[email]) {
+      return { success: false }; // Already exists
+    }
+
+    const secret = this.generateSecret();
+
+    const newAccount: MailAccount = {
+      email,
+      passwordHash: encodePassword(password),
+      name,
+      createdAt: new Date().toISOString(),
+      recoverySecret: secret,
+      emails: [],
+    };
+
+    db.accounts[email] = newAccount;
+    this.saveDB(db);
+    return { success: true, secret };
+  }
+
+  login(email: string, password: string): boolean {
+    const db = this.getDB();
+    const account = db.accounts[email];
+
+    if (!account) return false;
+
+    // In a real app we'd hash, here we just decode/compare or compare encoded
+    // Since we store encoded, we can compare encoded or decode.
+    // Let's decode to maintain the "hacking" simulation logic clearly
+    const storedPassword = decodePassword(account.passwordHash);
+    return storedPassword === password;
+  }
+
+  getAccount(email: string): MailAccount | null {
+    const db = this.getDB();
+    return db.accounts[email] || null;
+  }
+
+  // Recover password using the secret
+  recoverPassword(secret: string): string | null {
+    const db = this.getDB();
+    const account = Object.values(db.accounts).find(acc => acc.recoverySecret === secret);
+    
+    if (account) {
+      return decodePassword(account.passwordHash);
+    }
+    return null;
+  }
+
+  getEmails(email: string): Email[] {
+    const account = this.getAccount(email);
+    return account ? account.emails || [] : [];
+  }
+
+
+  // Helper to add emails (e.g. welcome emails)
+  addEmails(email: string, newEmails: Email[]) {
+    const db = this.getDB();
+    const account = db.accounts[email];
+
+    if (account) {
+      account.emails = [...newEmails, ...account.emails];
+      this.saveDB(db);
+    }
+  }
+  // Update specific fields of an email
+  updateEmail(emailAddress: string, emailId: string, updates: Partial<Email>) {
+    const db = this.getDB();
+    const account = db.accounts[emailAddress];
+
+    if (account && account.emails) {
+      account.emails = account.emails.map(email => 
+        email.id === emailId ? { ...email, ...updates } : email
+      );
+      this.saveDB(db);
+    }
+  }
+  // Delete an email permanently
+  deleteEmail(emailAddress: string, emailId: string) {
+    const db = this.getDB();
+    const account = db.accounts[emailAddress];
+
+    if (account && account.emails) {
+      account.emails = account.emails.filter(email => email.id !== emailId);
+      this.saveDB(db);
+    }
+  }
+}
+
+export const MailService = new MailServiceImpl();

--- a/src/utils/memory.ts
+++ b/src/utils/memory.ts
@@ -33,6 +33,7 @@ export const STORAGE_KEYS = {
     TRUSTMAIL_ACCOUNTS: 'trustmail_accounts', // Database of created accounts
     TRUSTMAIL_CURRENT: 'global_mail_account', // Currently logged in user for the website
     GLOBAL_MAILBOX: 'global_mailbox', // Legacy mailbox backup
+    MAIL_SERVER_DB: 'aurora_mail_server_db', // Simulated Cloud Mail Server DB
 } as const;
 
 const MEMORY_CONFIG = {
@@ -63,7 +64,8 @@ const MEMORY_CONFIG = {
             STORAGE_KEYS.VERSION,
             STORAGE_KEYS.INSTALLED_APPS,
             STORAGE_KEYS.TRUSTMAIL_ACCOUNTS, // Account DB is "hard"
-            STORAGE_KEYS.GLOBAL_MAILBOX // Legacy data is "hard"
+            STORAGE_KEYS.GLOBAL_MAILBOX, // Legacy data is "hard"
+            STORAGE_KEYS.MAIL_SERVER_DB // Simulated Cloud DB
         ] as string[],
         prefixes: [] // Future proofing
     }


### PR DESCRIPTION
  Changes:
  - TrustMail now creates accounts only in ~/.Config/mail.json
  - Mail app reads credentials from filesystem instead of localStorage
  - Removed localStorage keys: trustmail_accounts, global_mail_account, global_mailbox
  - One account per OS user enforced via mail.json existence check
  - Removed STORAGE_KEYS dependency from Mail.tsx
  - Simplified TrustMail by removing restore/session logic

  Migration path:
  - Users must create new accounts via TrustMail website
  - Existing localStorage accounts are no longer supported
  
This change will require a hard reset in order to use the Mail app, as the old system was a temporary placeholder. We couldn't keep it, sorry