### PR TITLE
feat: add history command

### DIFF
--- a/src/hooks/useTerminalLogic.tsx
+++ b/src/hooks/useTerminalLogic.tsx
@@ -499,6 +499,15 @@ export function useTerminalLogic(
     []
   );
 
+  // Command history management functions
+  const getCommandHistoryFn = useCallback(() => {
+    return commandHistory;
+  }, [commandHistory]);
+
+  const clearCommandHistoryFn = useCallback(() => {
+    setCommandHistory([]);
+  }, []);
+
   const executeCommand = async (cmdInput: string) => {
     if (promptState && promptResolverRef.current) {
       const resolver = promptResolverRef.current;
@@ -824,6 +833,8 @@ export function useTerminalLogic(
                       setIsSudoAuthorized,
                       verifyPassword,
                       t,
+                      getCommandHistory: getCommandHistoryFn,
+                      clearCommandHistory: clearCommandHistoryFn,
                     });
 
                     if (result.output) scriptOutput.push(...result.output);
@@ -896,6 +907,8 @@ export function useTerminalLogic(
             verifyPassword: verifyPassword,
             onLaunchApp: onLaunchApp,
             t, // Inject translation function
+            getCommandHistory: getCommandHistoryFn,
+            clearCommandHistory: clearCommandHistoryFn,
           });
 
           cmdOutput = result.output;

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -448,6 +448,10 @@ export const de: TranslationDict = {
         description: 'Einen Befehl als anderer Benutzer ausführen',
         usage: 'sudo [optionen] [befehl]',
       },
+      history: {
+        description: 'Terminal-Befehlsverlauf anzeigen',
+        usage: 'history [-c] [n]',
+      },
     },
   },
   placeholderApp: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -458,6 +458,10 @@ export const en: TranslationDict = {
         description: 'Execute a command as another user',
         usage: 'sudo [options] [command]',
       },
+      history: {
+        description: 'Show terminal command history',
+        usage: 'history [-c] [n]',
+      },
     },
   },
   placeholderApp: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -513,6 +513,10 @@ export const es: TranslationDict = {
         description: 'Ejecutar un comando como otro usuario',
         usage: 'sudo [opciones] [comando]',
       },
+      history: {
+        description: 'Mostrar historial de comandos del terminal',
+        usage: 'history [-c] [n]',
+      },
     },
   },
   placeholderApp: {

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -515,6 +515,10 @@ export const fr: TranslationDict = {
         description: 'Exécuter une commande en tant qu\'autre utilisateur',
         usage: 'sudo [options] [commande]',
       },
+      history: {
+        description: 'Afficher l\'historique des commandes du terminal',
+        usage: 'history [-c] [n]',
+      },
     },
   },
   placeholderApp: {

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -454,6 +454,10 @@ export const pt: TranslationDict = {
         description: 'Executar um comando como outro usuário',
         usage: 'sudo [opcoes] [comando]',
       },
+      history: {
+        description: 'Mostrar histórico de comandos do terminal',
+        usage: 'history [-c] [n]',
+      },
     },
   },
   placeholderApp: {

--- a/src/i18n/locales/ro.ts
+++ b/src/i18n/locales/ro.ts
@@ -512,6 +512,10 @@ export const ro: TranslationDict = {
                 description: 'Execută o comandă ca alt utilizator',
                 usage: 'sudo [opțiuni] [comandă]',
             },
+            history: {
+                description: 'Afișează istoricul comenzilor din terminal',
+                usage: 'history [-c] [n]',
+            },
         },
     },
     placeholderApp: {

--- a/src/utils/fileSystemUtils.ts
+++ b/src/utils/fileSystemUtils.ts
@@ -415,6 +415,7 @@ export const initialFileSystem: any = {
                 { name: 'su', type: 'file', permissions: '-rwsr-xr-x', owner: 'root', content: '#!/bin/bash\n#command su\n# switch user' },
                 { name: 'sudo', type: 'file', permissions: '-rwsr-xr-x', owner: 'root', content: '#!/bin/bash\n#command sudo\n# execute as superuser' },
                 { name: 'reset', type: 'file', permissions: '-rwxr-xr-x', owner: 'root', content: '#!/bin/bash\n#command reset\n# reset system' },
+                { name: 'history', type: 'file', permissions: '-rwxr-xr-x', owner: 'root', content: '#!/bin/bash\n#command history\n# display command history' },
             ],
         },
         // Boot loader files

--- a/src/utils/terminal/commands/history.ts
+++ b/src/utils/terminal/commands/history.ts
@@ -1,0 +1,50 @@
+import { TerminalCommand } from '../types';
+
+export const history: TerminalCommand = {
+    name: 'history',
+    description: 'Show terminal command history',
+    descriptionKey: 'terminal.commands.history.description',
+    usage: 'history [-c] [n]',
+    usageKey: 'terminal.commands.history.usage',
+    execute: ({ args, getCommandHistory, clearCommandHistory }) => {
+        const commandHistory = getCommandHistory();
+
+        // Parse arguments
+        const clearFlag = args.includes('-c');
+
+        // Handle -c flag (clear history)
+        if (clearFlag) {
+            clearCommandHistory();
+            return { output: ['Command history cleared'] };
+        }
+
+        // Handle numeric argument (show last N commands)
+        let limit = commandHistory.length;
+        const numericArg = args.find(arg => !arg.startsWith('-') && !isNaN(parseInt(arg, 10)));
+
+        if (numericArg) {
+            const parsedLimit = parseInt(numericArg, 10);
+            if (parsedLimit > 0) {
+                limit = parsedLimit;
+            }
+        }
+
+        // Display history
+        if (commandHistory.length === 0) {
+            return { output: [] };
+        }
+
+        // Get the last 'limit' commands
+        const startIndex = Math.max(0, commandHistory.length - limit);
+        const commandsToShow = commandHistory.slice(startIndex);
+
+        // Format output with line numbers (1-indexed from the start of full history)
+        const output = commandsToShow.map((cmd, index) => {
+            const lineNumber = startIndex + index + 1;
+            const paddedNumber = lineNumber.toString().padStart(5, ' ');
+            return `${paddedNumber}  ${cmd}`;
+        });
+
+        return { output };
+    },
+};

--- a/src/utils/terminal/registry.ts
+++ b/src/utils/terminal/registry.ts
@@ -25,6 +25,7 @@ import { chown } from './commands/chown';
 import { su } from './commands/su';
 import { sudo } from './commands/sudo';
 import { exit } from './commands/exit';
+import { history } from './commands/history';
 import { unlockDeveloperMode } from '../integrity';
 
 // Hidden system command for development
@@ -71,6 +72,7 @@ export const commands: Record<string, TerminalCommand> = {
     su,
     sudo,
     exit,
+    history,
     'dev-unlock': _sys_dev_override_cmd
 };
 

--- a/src/utils/terminal/types.ts
+++ b/src/utils/terminal/types.ts
@@ -23,6 +23,8 @@ export interface CommandContext {
     verifyPassword: (username: string, passwordToTry: string) => boolean;
     print: (content: string | React.ReactNode) => void;
     t: (key: string, options?: any) => string;
+    getCommandHistory: () => string[];
+    clearCommandHistory: () => void;
 }
 
 export interface CommandResult {


### PR DESCRIPTION
  ## Add `history` command to Terminal

  This PR implements the `history` command for the terminal, similar to the Unix/Linux command.

  ### Features

  - **Display command history**: Shows all previously entered commands with line numbers
  - **Limit output**: `history N` displays only the last N commands
  - **Clear history**: `history -c` clears the entire command history

  ### Implementation Details

  - Added `history` command implementation in `src/utils/terminal/commands/history.ts`
  - Registered command in `src/utils/terminal/registry.ts`
  - Added binary file in virtual filesystem at `/bin/history` for command discovery
  - Extended `CommandContext` interface with history management functions:
    - `getCommandHistory()`: Retrieves current command history
    - `clearCommandHistory()`: Clears all history entries
  - Integrated with `useTerminalLogic` hook to ensure state consistency between command execution and history persistence
  - Added translations for all supported languages
