### PR TITLE
fix(i18n): add missing appStore.installing translation key

### DIFF
--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -305,6 +305,7 @@ export const de: TranslationDict = {
     },
     "size": "Größe",
     "sizeUnknown": "Unbekannt",
+    "installing": "Installieren...",
     "install": "Installieren",
     "uninstall": "Deinstallieren",
     "open": "Öffnen",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -322,6 +322,7 @@ export const en: TranslationDict = {
     },
     size: 'Size',
     sizeUnknown: 'Unknown',
+    installing: 'Installing',
     install: 'Install',
     uninstall: 'Uninstall',
     open: 'Open',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -305,6 +305,7 @@ export const es: TranslationDict = {
     },
     "size": "Tamaño",
     "sizeUnknown": "Desconocido",
+    "installing": "Instalando...",
     "install": "Instalar",
     "uninstall": "Desinstalar",
     "open": "Abrir",

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -305,6 +305,7 @@ export const tr: TranslationDict = {
     },
     "size": "Boyut",
     "sizeUnknown": "Bilinmiyor",
+    "installing": "Yükleniyor...",
     "install": "Al",
     "uninstall": "Kaldır",
     "open": "Aç",


### PR DESCRIPTION
## Summary
Fixes #179 — "appStore.installing" was displayed as a raw key instead of translated text when installing apps.

## Root Cause
The `appStore.installing` i18n key was referenced in `AppCard.tsx` line 112 but was missing from all locale files (en/de/es/tr).

## Changes
Added `installing` key to the `appStore` section in all four locale files:
- `en.ts`: `installing: 'Installing'`
- `de.ts`: `installing: 'Installieren...'`
- `es.ts`: `installing: 'Instalando...'`
- `tr.ts`: `installing: 'Yükleniyor...'`

## Before
![Before](https://github.com/user-attachments/assets/05bd3975-3e2c-43c0-b050-f9e1701cd0d4)

## Type of Change
- [x] Bug fix (i18n)